### PR TITLE
fix: Sec-WebSocket-Protocol

### DIFF
--- a/lib/faye/websocket/protocol8_parser.js
+++ b/lib/faye/websocket/protocol8_parser.js
@@ -135,10 +135,19 @@ var instance = {
     
     var stream = this._stream;
     try {
-      stream.write( 'HTTP/1.1 101 Switching Protocols\r\n' +
-                    'Upgrade: websocket\r\n' +
-                    'Connection: Upgrade\r\n' +
-                    'Sec-WebSocket-Accept: ' + accept + '\r\n\r\n');
+      var res_headers= [
+        'HTTP/1.1 101 Switching Protocols',
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        'Sec-WebSocket-Accept: ' + accept
+      ];
+
+      if(this._socket.request.headers['sec-websocket-protocol']) {
+        var echo = this._socket.request.headers['sec-websocket-protocol'].split(',')[0];
+        res_headers.push('Sec-WebSocket-Protocol: ' + echo);
+      }
+      
+      stream.write(res_headers.concat('', '').join('\r\n'));
     } catch (e) {}
   },
   
@@ -377,4 +386,3 @@ for (var key in instance)
   Protocol8Parser.prototype[key] = instance[key];
 
 module.exports = Protocol8Parser;
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 , "author"          : "James Coglan <jcoglan@gmail.com> (http://jcoglan.com/)"
 , "keywords"        : ["websocket"]
 
-, "version"         : "0.1.2"
+, "version"         : "0.1.3"
 , "engines"         : {"node": ">=0.4.0"}
 , "main"            : "./lib/faye/websocket"
 , "devDependencies" : {"jsclass": ">=3.0.4"}


### PR DESCRIPTION
Sec-WebSocket-Protocol should be sent back to the client to confirm sub-protocol of connection.

See: http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-08#page-57
