### PR TITLE
Issue a single `write` per frame for protocol8

### DIFF
--- a/lib/faye/websocket/common.js
+++ b/lib/faye/websocket/common.js
@@ -1,0 +1,8 @@
+var bufferConcat = function (buf_a, buf_b) {
+  var dst = new Buffer(buf_a.length + buf_b.length);
+  buf_a.copy(dst);
+  buf_b.copy(dst, buf_a.length);
+  return dst;
+}
+
+module.exports.bufferConcat = bufferConcat;

--- a/lib/faye/websocket/draft75_parser.js
+++ b/lib/faye/websocket/draft75_parser.js
@@ -1,3 +1,5 @@
+var common = require('./common');
+
 var Draft75Parser = function(webSocket, stream) {
   this._socket    = webSocket;
   this._stream    = stream;
@@ -31,10 +33,10 @@ var instance = {
   
   frame: function(data) {
     var stream = this._stream;
+    var buf = common.bufferConcat(this.FRAME_START, new Buffer(data, 'utf8'));
+    buf = common.bufferConcat(buf, this.FRAME_END);
     try {
-      stream.write(this.FRAME_START, 'binary');
-      stream.write(new Buffer(data), 'utf8');
-      stream.write(this.FRAME_END, 'binary');
+      stream.write(buf, 'binary');
       return true;
     } catch (e) {
       return false;

--- a/lib/faye/websocket/protocol8_parser.js
+++ b/lib/faye/websocket/protocol8_parser.js
@@ -1,4 +1,5 @@
-var crypto = require('crypto');
+var crypto = require('crypto'),
+    common = require('./common');
 
 var Handshake = function(uri, stream) {
   this._uri    = uri;
@@ -204,8 +205,8 @@ var instance = {
     }
     
     var buf = frame;
-    if (mask) buf = this._bufferConcat(buf, new Buffer(mask));
-    if (data.length) buf = this._bufferConcat(buf, new Buffer(data, 'utf8'));
+    if (mask) buf = commmon.bufferConcat(buf, new Buffer(mask));
+    if (data.length) buf = common.bufferConcat(buf, new Buffer(data, 'utf8'));
     try {
       stream.write(buf, 'binary');
       return true;
@@ -371,13 +372,6 @@ var instance = {
       unmasked[i] = b;
     }
     return unmasked;
-  },
-
-  _bufferConcat: function (buf_a, buf_b) {
-    var dst = new Buffer(buf_a.length + buf_b.length);
-    buf_a.copy(dst);
-    buf_b.copy(dst, buf_a.length);
-    return dst;
   }
 };
 


### PR DESCRIPTION
Issuing a `write` call is usually quite expensive. Additionally, many client implementations expect to receive big chunks of data in a single go.

Issuing a single `write` with more data is always a better, more robust and usually significantly faster.
