### PR TITLE
Fix for closing a socket in the CONNECTING state

### DIFF
--- a/lib/faye/websocket/api.js
+++ b/lib/faye/websocket/api.js
@@ -57,9 +57,7 @@ var API = {
   close: function(code, reason, ack) {
     if (this.readyState === API.CLOSING ||
         this.readyState === API.CLOSED) return;
-    
-    this.readyState = API.CLOSING;
-    
+
     var close = function() {
       this.readyState = API.CLOSED;
       if (this._pingLoop) clearInterval(this._pingLoop);
@@ -68,15 +66,19 @@ var API = {
       event.initEvent('close', false, false);
       this.dispatchEvent(event);
     };
-    
+
     if (this.readyState === API.CONNECTING) {
       close.call(this);
-    } else if (ack !== false) {
-      if (this._parser.close) this._parser.close(code, reason, close, this);
-      else close.call(this);
     } else {
-      if (this._parser.close) this._parser.close(code, reason);
-      close.call(this);
+      this.readyState = API.CLOSING;
+
+      if (ack !== false) {
+        if (this._parser.close) this._parser.close(code, reason, close, this);
+        else close.call(this);
+      } else {
+        if (this._parser.close) this._parser.close(code, reason);
+        close.call(this);
+      }
     }
   }
 };


### PR DESCRIPTION
this.readyState was squashed before being checked. I reorganized the logic a little in the close method in api.js to fix it.
