### PR TITLE
Use singular repository to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
                         }
                       ]
 
-, "repositories"    : { "type"  : "git",
+, "repository"    : { "type"  : "git",
                         "url"   : "git://github.com/faye/faye-websocket-node.git"
                       }
 }


### PR DESCRIPTION
The key repositories in package.json is not supported and gives a warning during npm install

```
npm WARN package.json faye-websocket@0.4.4 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
```

This request fixes the warning
