### PR TITLE
Forward networking error events to the websocket event listeners.

### DIFF
--- a/lib/faye/websocket/client.js
+++ b/lib/faye/websocket/client.js
@@ -2,7 +2,8 @@ var util   = require('util'),
     net    = require('net'),
     tls    = require('tls'),
     driver = require('websocket-driver'),
-    API    = require('./api');
+    API    = require('./api'),
+    Event  = require('./api/event');
 
 var Client = function(url, protocols, options) {
   this.url     = url;
@@ -35,9 +36,13 @@ var Client = function(url, protocols, options) {
 
   API.call(this, options);
 
-  ['error', 'end'].forEach(function(event) {
-    this._stream.on(event, function() { self._finalize('', 1006) });
-  }, this);
+  this._stream.on('end', function() { self._finalize('', 1006) });
+  this._stream.on('error', function(event) {
+    var evt = new Event('error', {reason:'Networking error: ' + event.code});
+    evt.initEvent('error', false, false);
+    self.dispatchEvent(evt);
+    self._finalize('', 1006);
+  });
 };
 util.inherits(Client, API);
 


### PR DESCRIPTION
Handshake failures from HTTP were being fired as errors while connection errors failed to show up. Dispatch network failure events (like connection refused, etc.)
