### PR TITLE
Test for faye/websocket-driver-node#8

### DIFF
--- a/lib/faye/websocket/api.js
+++ b/lib/faye/websocket/api.js
@@ -98,7 +98,7 @@ var instance = {
   },
 
   close: function() {
-    if (this.readyState === API.OPEN) this.readyState = API.CLOSING;
+    if (this.readyState !== API.CLOSED) this.readyState = API.CLOSING;
     this._driver.close();
   },
 


### PR DESCRIPTION
If you decide to open a client connection but then close it before the
TCP connection succeeds, the websocket-driver change tested by this
commit will ensure that it will actually close, rather than ignoring the
close() method.

The change to API.close also seems correct to me, though I'm not sure
if there are any observable changes if you don't do it.
