### PR TITLE
Allow use of pre-existing connection

### DIFF
--- a/lib/faye/websocket/client.js
+++ b/lib/faye/websocket/client.js
@@ -8,8 +8,10 @@ var util   = require('util'),
 var Client = function(url, protocols, options) {
   options = options || {};
 
+  var self      = this,
+      onConnect = function() { self._driver.start() }
+
   this.url     = url;
-  this._uri    = require('url').parse(url);
   this._driver = driver.client(url, {maxLength: options.maxLength, protocols: protocols});
 
   ['open', 'error'].forEach(function(event) {
@@ -19,19 +21,23 @@ var Client = function(url, protocols, options) {
     });
   }, this);
 
-  var secure     = (this._uri.protocol === 'wss:'),
-      onConnect  = function() { self._driver.start() },
-      tlsOptions = {},
-      self       = this;
+  if (options.connection) {
+    this._stream = options.connection;
+    process.nextTick(onConnect);
+  } else {
+    var uri        = require('url').parse(url),
+        secure     = (uri.protocol === 'wss:'),
+        tlsOptions = {}
 
-  if (options.ca) tlsOptions.ca = options.ca;
+    if (options.ca) tlsOptions.ca = options.ca;
 
-  var connection = secure
-                 ? tls.connect(this._uri.port || 443, this._uri.hostname, tlsOptions, onConnect)
-                 : net.createConnection(this._uri.port || 80, this._uri.hostname);
-
-  this._stream = connection;
-  if (!secure) this._stream.on('connect', onConnect);
+    if (secure) {
+      this._stream = tls.connect(uri.port || 443, uri.hostname, tlsOptions, onConnect)
+    } else {
+      this._stream = net.createConnection(uri.port || 80, uri.hostname);
+      this._stream.on('connect', onConnect);
+    }
+  }
 
   API.call(this, options);
 };


### PR DESCRIPTION
For example, behind a corporate proxy, you might use the tunnel npm
module to create a connection that's tunneled through the proxy.
