### PR TITLE
Fix proxy connections to non-localhost SSL origins

### DIFF
--- a/lib/faye/websocket/client.js
+++ b/lib/faye/websocket/client.js
@@ -66,7 +66,7 @@ Client.prototype._configureProxy = function(proxy, originTLS) {
 
   this._proxy.on('connect', function() {
     if (secure) {
-      var options = {socket: self._stream};
+      var options = {socket: self._stream, servername: uri.hostname};
       for (name in originTLS) options[name] = originTLS[name];
       self._stream = tls.connect(options);
       self._configureStream();


### PR DESCRIPTION
The socket form of tls.connect needs to be told the server name it is
connecting to in order to validate the server certificate (and to
perform SNI). Without this change, just about any attempt to proxy to an
SSL origin will fail.

This name defaults to 'localhost':
  https://github.com/joyent/node/blob/v0.10/lib/tls.js#L1349
so an attempt to proxy to an SSL origin named 'localhost' would have
succeeded, which is why tests passed.
