### PR TITLE
Handle cases where the socket is closed before being passed to the server

### DIFF
--- a/lib/faye/websocket.js
+++ b/lib/faye/websocket.js
@@ -1,5 +1,5 @@
 // API references:
-// 
+//
 // * http://dev.w3.org/html5/websockets/
 // * http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#interface-eventtarget
 // * http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#interface-event
@@ -16,6 +16,7 @@ var WebSocket = function(request, socket, body, protocols, options) {
 
   var self = this;
   if (!this._stream || !this._stream.writable) return;
+  if (!this._stream.readable) return this._stream.end();
 
   var catchup = function() { self._stream.removeListener('data', catchup) };
   this._stream.on('data', catchup);

--- a/lib/faye/websocket/api.js
+++ b/lib/faye/websocket/api.js
@@ -143,7 +143,6 @@ var instance = {
     var stream = this._stream;
     if (stream) {
       if (stream.unpipe) stream.unpipe(this._driver.io);
-      stream.on('data', function() { stream.destroy() });
       stream.end();
     }
 


### PR DESCRIPTION
If the stream is not readable it means that other end has sent the FIN packet.
When this happens we can end the write site of the socket and bail out.

I don't know if this approach has side effects but it seems to work.
