### PR TITLE
Fix for the dropped status and reason arguments

### DIFF
--- a/lib/faye/websocket/api.js
+++ b/lib/faye/websocket/api.js
@@ -92,9 +92,9 @@ var instance = {
     return this._driver.ping(message, callback);
   },
 
-  close: function() {
+  close: function(status, reason, ack) {
     if (this.readyState !== API.CLOSED) this.readyState = API.CLOSING;
-    this._driver.close();
+    this._driver.close(reason, status);
   },
 
   _configureStream: function() {


### PR DESCRIPTION
Hello James,
    Here is a fix that we use for the dropped status and reason arguments. Please take a look, and see if you you approve. We tried faye-websocket version 0.10. Unfortunately, it did not fix our problem. It does seem, in my non-expert opinion, to be a related issue. 

   Thank you, 
      Ohad. 
