### PR TITLE
localAddress option for outgoing connections

### DIFF
--- a/lib/faye/websocket/client.js
+++ b/lib/faye/websocket/client.js
@@ -33,9 +33,15 @@ var Client = function(_url, protocols, options) {
 
   originTLS.ca = originTLS.ca || options.ca;
 
+  var socket_options = {
+    port: port,
+    host: endpoint.hostname,
+    localAddress: options.localAddress
+  };
+
   this._stream = secure
                ? tls.connect(port, endpoint.hostname, socketTLS, onConnect)
-               : net.connect(port, endpoint.hostname, onConnect);
+               : net.createConnection(socket_options, onConnect);
 
   if (proxy.origin) this._configureProxy(proxy, originTLS);
 


### PR DESCRIPTION
While the clear-text outgoing connections now accept nodes localAddress option, I have not added the functionality to the tls connections as yet. On line 43 there is an existing options object specifically for TLS connections..

Would you rather use the new `socket_options` var for both options? Or merge the `host`/`port`/`localAddress` properties to the existing `socketTLS` object?