### PR TITLE
Support SNI communication with a webserver

### DIFF
--- a/lib/faye/websocket/client.js
+++ b/lib/faye/websocket/client.js
@@ -32,6 +32,7 @@ var Client = function(_url, protocols, options) {
       self      = this;
 
   originTLS.ca = originTLS.ca || options.ca;
+  if (!socketTLS.servername) socketTLS.servername = endpoint.hostname;
 
   this._stream = secure
                ? tls.connect(port, endpoint.hostname, socketTLS, onConnect)


### PR DESCRIPTION
The option servername has to be set in order for connecting to a
webserver that requires SNI for certificate selection.

Also see here:
https://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback