### PR TITLE
Add /examples directory to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,5 @@
 .npmignore
 .travis.yml
 node_modules
+examples
 spec


### PR DESCRIPTION
Reduces the downloaded package size from 288K to 260K, meaning a faster `npm install`.