### PR TITLE
Set close timer before closing the driver.

### DIFF
--- a/lib/faye/websocket/api.js
+++ b/lib/faye/websocket/api.js
@@ -104,13 +104,13 @@ var instance = {
                       code + " is neither.");
 
     if (this.readyState !== API.CLOSED) this.readyState = API.CLOSING;
-    this._driver.close(reason, code);
-
     var self = this;
 
     this._closeTimer = setTimeout(function() {
       self._beginClose('', 1006);
     }, API.CLOSE_TIMEOUT);
+
+    this._driver.close(reason, code);
   },
 
   _configureStream: function() {
@@ -129,7 +129,7 @@ var instance = {
     });
   },
 
- _open: function() {
+  _open: function() {
     if (this.readyState !== API.CONNECTING) return;
 
     this.readyState = API.OPEN;


### PR DESCRIPTION
This fixes a race condition that prevented the close timer from being cleared in some special cases.

Fixes #64.