### PR TITLE
Fix hang on double close

### DIFF
--- a/lib/faye/websocket/api.js
+++ b/lib/faye/websocket/api.js
@@ -105,12 +105,14 @@ var instance = {
                       "The code must be either 1000, or between 3000 and 4999. " +
                       code + " is neither.");
 
-    if (this.readyState !== API.CLOSED) this.readyState = API.CLOSING;
-    var self = this;
+    if (this.readyState < API.CLOSING) {
+      var self = this;
+      this._closeTimer = setTimeout(function() {
+        self._beginClose('', 1006);
+      }, API.CLOSE_TIMEOUT);
+    }
 
-    this._closeTimer = setTimeout(function() {
-      self._beginClose('', 1006);
-    }, API.CLOSE_TIMEOUT);
+    if (this.readyState !== API.CLOSED) this.readyState = API.CLOSING;
 
     this._driver.close(reason, code);
   },

--- a/spec/double_close.js
+++ b/spec/double_close.js
@@ -1,0 +1,26 @@
+const WebSocket = require("..");
+const http = require("http");
+
+//
+// This script should terminate quickly. In 0.11.3, it hung for 30s due to
+// a left over timer.
+//
+
+var server = http.createServer();
+server.on("upgrade", function (request, socket, head) {
+  var ws = new WebSocket(request, socket, head);
+  ws.onclose = function (event) {
+    ws.close(); // the double close
+    server.close();
+  };
+});
+
+// Listen on random port.
+server.listen(0, () => {
+  const url = "ws://localhost:" + server.address().port;
+  const ws = new WebSocket.Client(url);
+
+  ws.onopen = function () {
+    ws.close();
+  };
+});


### PR DESCRIPTION
In the same vein as https://github.com/faye/faye-websocket-node/issues/64: calling `API#close` from a `close` event handler resulted in the `_closeTimer` never being cleared.

### Reproduction

1. Run the `spec/double_close.js` script in this PR.

Expected: script terminates right away

Observed (before this fix): script hangs for 30s then terminates

### Context

One could argue that one simply shouldn't call `close` from a close event handler, but it seems that sockjs 0.3.21 (current stable) does. A short example that reproduces the 30s hang using sockjs (which depends on `faye-websocket` 0.11.3 at present) is:
```js
const http = require('http')
const sockjs = require('sockjs')

const WebSocket = require('faye-websocket')

const sockjsServer = sockjs.createServer({
  sockjs_url: 'http://cdn.jsdelivr.net/sockjs/1.0.1/sockjs.min.js',
  prefix: '/test'
})

sockjsServer.on('connection', function (sockjsConnection) {
  sockjsConnection.on('close', function () {
    server.close()
  })
})

const server = http.createServer()
sockjsServer.installHandlers(server)

server.listen(0, function () { 
  const url = 'ws://localhost:' + server.address().port + '/test/websocket';
  const ws = new WebSocket.Client(url);
  ws.onopen = function () {
    ws.close()
  }
})
```
I think it comes from [here](https://github.com/sockjs/sockjs-node/blob/a8fca8e0afaf3906acfc7beafb18789290c2646c/src/trans-websocket.coffee#L144-L152) --- after the socket [closes](https://github.com/sockjs/sockjs-node/blob/a8fca8e0afaf3906acfc7beafb18789290c2646c/src/trans-websocket.coffee#L121-L122), it does an extra `close` for good measure.

Also, reading the code in `close`, there is already a guard on `this.readyState !== API.CLOSED`, which suggests that it is intended to handle multiple `close` calls.

### Review

The proposed fix is to not set the timer if the state was already `CLOSING` or `CLOSED` at the time `close` was called.
- The state could be set to `CLOSING` either from a previous call to `close`, in which case there should already be a `_closeTimer` set from that call, or because `_beginClose` has been called, which is what the timeout would do.
   https://github.com/faye/faye-websocket-node/blob/0be69bd810656eb9d6efdc1ebdfd01591fec47f6/lib/faye/websocket/api.js#L165
- If the state is already `CLOSED`, then the timer would not do anything in `_beginClose`, because of this condition
   https://github.com/faye/faye-websocket-node/blob/0be69bd810656eb9d6efdc1ebdfd01591fec47f6/lib/faye/websocket/api.js#L164

This required moving the `closerTimer` earlier; it is still before the call to the driver and so preserves the ordering change in #65 .

I tried to add a spec for this, but it looks like `jstest` forces an exit when the suite completes (I think [here](https://github.com/jcoglan/jstest/blob/081e94c942c1653428d9fa687b8d7291eb017a15/build/jstest.js#L2470-L2472)), which masks the bug. So, I've just included a separate test script for now. I'm not sure how best to approach testing this longer term.